### PR TITLE
deploy: always sign with PRIVATE_KEY (never PRIVATE_KEY_DEV)

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -5,7 +5,7 @@ jobs:
   rainix:
     runs-on: ubuntu-latest
     env:
-      DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+      DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Per project policy, deploy/CI workflows must always sign with `secrets.PRIVATE_KEY`. Replaces the `PRIVATE_KEY_DEV` fallback conditional in `rainix.yaml`.